### PR TITLE
Change all monetary values to numbers in the database instead of strings

### DIFF
--- a/src/app/budget/budget-add/budget-add.component.html
+++ b/src/app/budget/budget-add/budget-add.component.html
@@ -9,7 +9,8 @@
         <input id="subCategoryTitle" formControlName="subCategoryTitle">
     
         <label for="subCategoryValue">Amount</label>
-        <input id="subCategoryValue" formControlName="subCategoryValue">    
+        <input type="number" name="subCategoryValue" id="subCategoryValue" formControlName="subCategoryValue">
+        <!-- <input id="subCategoryValue" formControlName="subCategoryValue">     -->
     </div>
 </div>
 </form>
@@ -17,4 +18,3 @@
     <button (click)="addSubcategory()">Add New Subcategory</button>    
     <button (click)= "onSubmit(budgetForm)">OK</button>
 </div>
-

--- a/src/app/budget/budget-add/budget-add.component.scss
+++ b/src/app/budget/budget-add/budget-add.component.scss
@@ -22,3 +22,13 @@
     justify-content: space-between;
     margin-top: 10px;
 }
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type=number] {
+  -moz-appearance: textfield;
+}

--- a/src/app/budget/budget-edit/budget-edit.component.html
+++ b/src/app/budget/budget-edit/budget-edit.component.html
@@ -43,7 +43,7 @@
                             class="col-10"  
                             style="margin-left: 0.4rem;" 
                             id="startingValue" 
-                            type="text" 
+                            type="number" 
                         >    
                     </div>
                     <div class="col-3">
@@ -53,7 +53,7 @@
                             pInputText 
                             class="col-10" 
                             id="currentValue" 
-                            type="text" 
+                            type="number" 
                         > 
                     </div>
                     <button 
@@ -88,7 +88,7 @@
                             style="margin-left: 0.4rem;" 
                             pInputText 
                             formControlName="startingValue" 
-                            type="text"
+                            type="number"
                         >    
                     </div>
                     <div class="col-3">
@@ -97,7 +97,7 @@
                             class="col-10" 
                             pInputText 
                             formControlName="subCategoryValue" 
-                            type="text"
+                            type="number"
                         >        
                     </div>
                     <button

--- a/src/app/budget/budget-edit/budget-edit.component.scss
+++ b/src/app/budget/budget-edit/budget-edit.component.scss
@@ -9,6 +9,16 @@ input {
     text-align: left;
 }
 
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type=number] {
+    -moz-appearance: textfield;
+}
+
 .p-scrollpanel {
     :host ::ng-deep &.customScroll {
         .p-scrollpanel-bar {

--- a/src/app/budget/budget.component.ts
+++ b/src/app/budget/budget.component.ts
@@ -77,9 +77,7 @@ export class BudgetComponent implements OnInit, OnDestroy {
     if(subCategories.startingValue === subCategories.subCategoryValue) {
       return 100;
     } else if (subCategories.startingValue !== subCategories.subCategoryValue && subCategories.subCategoryValue > 0) {
-      let starting = parseInt(subCategories.startingValue);
-      let remaining = parseInt(subCategories.subCategoryValue);
-      let calc = (remaining / starting) * 100
+      let calc = (subCategories.subCategoryValue / subCategories.startingValue) * 100
       return calc
     } else {
       return 0

--- a/src/app/budget/expense-add/expense-add.component.html
+++ b/src/app/budget/expense-add/expense-add.component.html
@@ -6,7 +6,7 @@
         <label>Category</label>
         <p-multiSelect formControlName="expenseCategory" [options]="categoryOptions" [filter]="false" [showToggleAll]="false" [showHeader]="false" [selectionLimit]="1" [style]="{'width' : '100%'}"></p-multiSelect>
         <label for="expense-amount">Amount</label>
-        <input formControlName="expenseAmount" id="expense-amount" type="text">
+        <input formControlName="expenseAmount" id="expense-amount" type="number">
         <button (click)="onFormSubmit(expenseForm)">Create</button>
     </form>  
 

--- a/src/app/budget/expense-add/expense-add.component.scss
+++ b/src/app/budget/expense-add/expense-add.component.scss
@@ -14,3 +14,13 @@
         grid-template-rows: repeat(1fr, auto);
     }
 }
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type=number] {
+  -moz-appearance: textfield;
+}

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -3,7 +3,7 @@ import { AngularFirestore } from "@angular/fire/compat/firestore";
 import { AuthService } from './auth.service';
 import * as _ from 'lodash'
 
-export interface BudgetCategory {
+interface BudgetCategory {
   categoryTitle: string,
   subCategory: Array<string>,
 }
@@ -14,7 +14,7 @@ export class FirebaseService {
 
  subCategoryCopy: any;
  currentDocId!: string;
- expenseValue!: string;
+ expenseValue!: number;
  currentCategoryValue: any;
  fullCurrentBudgetCategory: any;
  queriedData: any;
@@ -58,20 +58,17 @@ export class FirebaseService {
     })
   }
 
-  getExpenseInfo(expenseValue: string, currentValue: string, fullCurrentBudgetCategory: any) {
+  getExpenseInfo(expenseValue: number, currentValue: string, fullCurrentBudgetCategory: any) {
     this.expenseValue = expenseValue
     this.currentCategoryValue = currentValue
     this.fullCurrentBudgetCategory = fullCurrentBudgetCategory
   }
 
-  private manipulateCategory(categoryCopy: any[], expenseValue: string, currentValue: any) {
+  private manipulateCategory(categoryCopy: any[], expenseValue: number, currentValue: any) {
     for (let i = 0; i < categoryCopy.length; i++) {
       if (_.isEqual(categoryCopy[i], this.fullCurrentBudgetCategory)) {
         categoryCopy.splice(i, 1);
-        let expenseNum = parseInt(expenseValue);
-        let currentNum = parseInt(currentValue);
-        let newVal = currentNum - expenseNum;
-        let newValString = newVal.toString();
+        let newValString = currentValue - expenseValue;
         this.currentCategoryValue = newValString;
         this.fullCurrentBudgetCategory.subCategoryValue = this.currentCategoryValue;
         this.subCategoryCopy.push(this.fullCurrentBudgetCategory);


### PR DESCRIPTION
Make all monetary values submit as numbers instead of strings across the app. Firebase now reflects number data instead of strings so I dont have to do unnecessary conversions to do calculations. This will also help make things easier when I make the necessary changes to allow for sub $1 amounts to calculate properly under a base 10 monetary system as my current implementation is working within the binary. 