### PR TITLE
Delete expenses associated with deleted budget subcategory

### DIFF
--- a/src/app/budget/budget-edit/budget-edit.component.ts
+++ b/src/app/budget/budget-edit/budget-edit.component.ts
@@ -66,6 +66,14 @@ export class BudgetEditComponent implements OnInit {
   }
 
   deleteCurrentSubcategory(i: number) {
+    if (this.config.data.subCategories[i].subCategoryValue < this.config.data.subCategories[i].startingValue) {
+      console.log('Cant Delete without removing expenses');
+      this.db.deleteExpensesOfDeletedSubCategory(this.config.data.subCategories[i].subCategoryTitle);
+      this.currentSubCats.removeAt(i);
+      this.isDeleteButtonVisibleCurrent = -1;
+      this.isDeleteButtonVisibleNew = -1;  
+      return
+    }
     this.currentSubCats.removeAt(i);
     this.isDeleteButtonVisibleCurrent = -1;
     this.isDeleteButtonVisibleNew = -1;

--- a/src/app/budget/budget-edit/budget-edit.component.ts
+++ b/src/app/budget/budget-edit/budget-edit.component.ts
@@ -86,6 +86,9 @@ export class BudgetEditComponent implements OnInit {
   }
 
   deleteEntireCategory() {
+    for (let i = 0; i < this.currentSubcategories.length; i++) {
+      this.db.deleteExpensesOfDeletedSubCategory(this.currentSubcategories[i].subCategoryTitle);
+    }
     this.db.deleteDocument(this.currentSubcategories, 'budgetCategory', 'subCategory');
     setTimeout(() => {
       this.ref.close();
@@ -103,7 +106,6 @@ export class BudgetEditComponent implements OnInit {
   }
 
   onSubmit(payload: any) {
-    console.log(payload);
     if (_.isEqual(payload.currentCategories, this.currentSubcategories) && this.config.data.categoryTitle === payload.categoryTitle && payload.newSubCategories.length === 0) {
       this.ref.close();
       console.log("No updates were made");

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -132,6 +132,7 @@ export class FirebaseService {
  * @param budgetCategoryObject 
  */
   expenseDeleteOperation(budgetCategoryObject: any) {
+    console.log(budgetCategoryObject);
     let query = this.database.collection("users").doc(this.auth.userId)
     .collection("budgetCategory", ref => ref.where("subCategory", "array-contains", budgetCategoryObject.currentBudgetCategoryData)).get();
     query.subscribe(result => {
@@ -161,6 +162,21 @@ export class FirebaseService {
   deleteExpense(expenseName: string, expenseAmount: number, expenseCategory: string) {
     let query = this.database.collection("users").doc(this.auth.userId)
     .collection("budgetExpense", ref => ref.where("expenseName", "==", expenseName).where("expenseAmount", "==", expenseAmount).where("expenseCategory", "==", expenseCategory)).get();
+    query.subscribe(result => {
+      result.forEach(final => {
+        this.database.collection("users").doc(this.auth.userId).collection("budgetExpense").doc(final.id).delete();
+      })
+    })
+  }
+
+/**
+ * Used to delete all related expenses to a subCategory that is being deleted. This is needed 
+ * because if the subCategory is deleted then the left over expenses logged against that 
+ * subCategory will not be deletable because their subCategory parent is gone.
+ * @param subCategoryTitle 
+ */
+  deleteExpensesOfDeletedSubCategory(subCategoryTitle: string) {
+    let query = this.database.collection("users").doc(this.auth.userId).collection("budgetExpense", ref => ref.where("expenseCategory", '==', subCategoryTitle)).get();
     query.subscribe(result => {
       result.forEach(final => {
         this.database.collection("users").doc(this.auth.userId).collection("budgetExpense").doc(final.id).delete();

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -132,7 +132,6 @@ export class FirebaseService {
  * @param budgetCategoryObject 
  */
   expenseDeleteOperation(budgetCategoryObject: any) {
-    console.log(budgetCategoryObject);
     let query = this.database.collection("users").doc(this.auth.userId)
     .collection("budgetCategory", ref => ref.where("subCategory", "array-contains", budgetCategoryObject.currentBudgetCategoryData)).get();
     query.subscribe(result => {


### PR DESCRIPTION
When a budget category is completely deleted all of the sub categories go with it. If there were ever any expenses that were made against any of those sub categories, they need to be deleted along with it as not to produce expense confusion. This branch does just that using the method from the firebase service that deletes expenses for the selected sub category