### PR TITLE
Add budget reset functionality

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { ScrollPanelModule } from 'primeng/scrollpanel';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { BudgetComponent } from './budget/budget.component';
 import { ProgressBarComponent } from './budget/progress-bar/progress-bar.component';
+import { ConfirmPopupModule } from 'primeng/confirmpopup';
 import { BudgetAddComponent } from './budget/budget-add/budget-add.component';
 import { DynamicDialogModule } from 'primeng/dynamicdialog';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'; 
@@ -62,7 +63,8 @@ import { IncomeAddComponent } from './budget-overview/income-add/income-add.comp
     MultiSelectModule,
     ButtonModule,
     InputTextModule,
-    MenuModule
+    MenuModule,
+    ConfirmPopupModule
   ],
 
   entryComponents: [

--- a/src/app/budget/budget.component.html
+++ b/src/app/budget/budget.component.html
@@ -3,6 +3,10 @@
         <h1 class="header-container__text">Monthly Budget</h1>
         <fa-icon [icon]="faPlusCircle" class="header-container__add-icon" (click)="menu.toggle($event)"></fa-icon> 
     </div>
+    <div *ngIf="budgetCategory.length > 0" class="flex justify-content-center">
+        <p-confirmPopup [showTransitionOptions]="'100ms'" [hideTransitionOptions]="'100ms'"></p-confirmPopup>
+        <button (click)="confirmBudgetReset($event)" pButton label="Reset Budget" [style]="{'margin-bottom' : '0.5rem', 'font-size': '1.2rem', 'height': '1.4rem'}" class="p-button-danger p-button-round"></button>
+    </div>
     <p-menu #menu [popup]="true" [model]="menuItems"></p-menu>   
     <div class="category-panel-container">
         <p-scrollPanel styleClass="customScrollStyles">

--- a/src/app/budget/budget.component.scss
+++ b/src/app/budget/budget.component.scss
@@ -3,7 +3,6 @@
 }
 
 .header-container {
-    margin-bottom: 5%;
     display: flex;
     justify-content: space-between;
 

--- a/src/app/budget/budget.component.ts
+++ b/src/app/budget/budget.component.ts
@@ -9,12 +9,13 @@ import { BudgetEditComponent } from './budget-edit/budget-edit.component';
 import { Subscription } from 'rxjs';
 import { MenuItem } from 'primeng/api';
 import { ExpenseAddComponent } from './expense-add/expense-add.component';
+import { ConfirmationService } from 'primeng/api';
 
 @Component({
   selector: 'app-budget',
   templateUrl: './budget.component.html',
   styleUrls: ['./budget.component.scss'],
-  providers: [DialogService, DynamicDialogRef]
+  providers: [DialogService, DynamicDialogRef, ConfirmationService]
 })
 export class BudgetComponent implements OnInit, OnDestroy {
 
@@ -26,7 +27,7 @@ export class BudgetComponent implements OnInit, OnDestroy {
 
   isMenuVisible!: number;
 
-  budgetCategory: any[] = [];
+  budgetCategory: any = [];
 
   budgetSubCategory: any[] = [];
 
@@ -45,7 +46,7 @@ export class BudgetComponent implements OnInit, OnDestroy {
     showHeader: false,
   }
 
-  constructor(public dialogService: DialogService, public ref: DynamicDialogRef, public db: FirebaseService) { }
+  constructor(private dialogService: DialogService, private ref: DynamicDialogRef, private db: FirebaseService, private confirmationService: ConfirmationService) { }
 
   ngOnInit(): void {
     this.getBudgetSubscription$ = this.db.getCategories()
@@ -54,14 +55,32 @@ export class BudgetComponent implements OnInit, OnDestroy {
      })
      this.menuItems = [
        {label: 'New Budget Category', command: () => { this.showBudgetCategoryModal(); }},
-       {label: 'Add Expense', command: () => { this.showExpenseModal(); }}
+       {label: 'Add Expense', command: () => { this.showExpenseModal(); }},
      ]
    }
  
    ngOnDestroy(): void {
      this.getBudgetSubscription$.unsubscribe();
    }
+
+   confirmBudgetReset(event: any) {
+     this.confirmationService.confirm({
+       target: event.target,
+       message: "Are you sure you want to reset your budget? All of your budget values will be reset and all expenses logged will be deleted",
+       icon: 'pi pi-exclamation-triangle',
+       accept: () => {
+         this.db.resetWholeBudget();
+         this.confirmationService.close();
+       },
+       reject: () => {
+         this.confirmationService.close();
+       }
+     })
+   }
  
+   resetEntireBudget() {
+     this.db.resetWholeBudget();
+   }
 
   openBudgetEditModal(index: number) {
     const ref = this.dialogService.open(BudgetEditComponent, {

--- a/src/app/mobile-footer/mobile-footer.component.html
+++ b/src/app/mobile-footer/mobile-footer.component.html
@@ -2,16 +2,12 @@
     <a 
         routerLink="/overview" 
         class="nav-icon-container" 
-        (click)="changeActiveLink()" 
-        [ngClass]="{'nav-icon-container--active' : isActiveLink === 'overview'}"
     >
         <fa-icon [icon]="faReceipt" class="navigation-icon"></fa-icon>
     </a>
     <a 
         routerLink="/budget" 
-        (click)="changeActiveLink()" 
         class="nav-icon-container" 
-        [ngClass]="{'nav-icon-container--active' : isActiveLink === 'budget'}"
     >
         <fa-icon [icon]="faWallet" class="navigation-icon"></fa-icon>
     </a>

--- a/src/app/mobile-footer/mobile-footer.component.scss
+++ b/src/app/mobile-footer/mobile-footer.component.scss
@@ -18,10 +18,6 @@
         justify-content: center;
         align-items: center;
         background-color: rgb(252, 250, 248);
-
-        &--active {
-            background-color: rgb(66, 111, 239);
-        }
         
         &:focus, &:visited, &:active, &:link {
             outline: none;

--- a/src/app/mobile-footer/mobile-footer.component.ts
+++ b/src/app/mobile-footer/mobile-footer.component.ts
@@ -13,16 +13,6 @@ export class MobileFooterComponent implements OnInit {
   faChartPie = faChartPie;
   faBalanceScale = faBalanceScale;
   faPlusSquare = faPlusSquare;
-
-  isActiveLink: string = 'overview'
-
-  changeActiveLink() {
-    if (this.isActiveLink === 'overview') {
-      this.isActiveLink = 'budget'
-    } else {
-      this.isActiveLink = 'overview'
-    }
-  }
   
   constructor() { }
 

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -3,9 +3,9 @@ import { AngularFirestore, DocumentData } from "@angular/fire/compat/firestore";
 import { AuthService } from './auth.service';
 import * as _ from 'lodash'
 
-interface BudgetCategory {
+export interface BudgetCategory {
   categoryTitle: string,
-  subCategory: Array<string>,
+  subCategory: any[],
 }
 
 interface BudgetExpense {
@@ -210,6 +210,23 @@ export class FirebaseService {
     query.subscribe(first => {
       first.forEach(result => {
         this.database.collection("users").doc(this.auth.userId).collection(collection).doc(result.id).delete();
+      })
+    })
+  }
+
+  resetWholeBudget() {
+    this.database.collection("users").doc(this.auth.userId).collection("budgetCategory").get().subscribe(options => {
+      options.forEach(result => {
+        let category = result.data()
+        for (let i = 0; i < category.subCategory.length; i++) { 
+          category.subCategory[i].subCategoryValue = category.subCategory[i].startingValue;
+        }
+        this.database.collection("users").doc(this.auth.userId).collection("budgetCategory").doc(result.id).set(category, {merge: true});
+      })
+    })
+    this.database.collection("users").doc(this.auth.userId).collection("budgetExpense").get().subscribe(result => {
+      result.forEach(final => {
+        this.database.collection("users").doc(this.auth.userId).collection("budgetExpense").doc(final.id).delete();
       })
     })
   }


### PR DESCRIPTION
Added a new method to the firebase service to reset all budget sub category values to their starting values. Added a button to the budget component that spawns a popup modal informing the user of the operation that is about to occur. The OK button is tied to the method that performs this operation while the cancel button just closes the dialog. Also removed the footer navigation code that makes the buttons light up when active because it was just too clunky. Ill make a better attempt at this later on.